### PR TITLE
fix(upload): adding circleci workflow to publish to artifactory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,4 +40,4 @@ workflows:
             filters:
               branches:
                 only:
-                  - artifactory
+                  - artifactory #master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,14 +22,7 @@ jobs:
       indigo_image_version: python:3.6.2-indigo
     steps:
         - shared/restore_workspace_cache
-        - run:
-            no_output_timeout: 30m
-            command: |
-              git config --global user.email "automation@indigoag.com"
-              git config --global user.name "Automation"
-              . local-env/bin/activate
-              semantic-release publish
-              python setup.py sdist upload -r local
+        - python/semantic_release_publish
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,12 @@ jobs:
       indigo_image_version: python:3.6.2-indigo
     steps:
       - checkout
-      - python/setup_local_env_install_deps
+      - run:
+          name: Setup local-env and pip install
+          command: |
+              python -m venv local-env
+              . local-env/bin/activate
+              pip install -r requirements.txt
       - shared/save_workspace_cache
   release:
     executor:
@@ -20,7 +25,6 @@ jobs:
         - run:
             no_output_timeout: 30m
             command: |
-              . local-env/bin/activate
               git config --global user.email "automation@indigoag.com"
               git config --global user.name "Automation"
               . local-env/bin/activate
@@ -40,4 +44,4 @@ workflows:
             filters:
               branches:
                 only:
-                  - artifactory #master
+                  - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+version: 2.1
+orbs:
+  shared: indigo/shared@volatile
+  python: indigo/python@volatile
+jobs:
+  build:
+    executor:
+      name: shared/default
+      indigo_image_version: python:3.6.2-indigo
+    steps:
+      - checkout
+      - python/setup_local_env_install_deps
+      - shared/save_workspace_cache
+  release:
+    executor:
+      name: shared/default
+      indigo_image_version: python:3.6.2-indigo
+    steps:
+        - shared/restore_workspace_cache
+        - run:
+            no_output_timeout: 30m
+            command: |
+              . local-env/bin/activate
+              git config --global user.email "automation@indigoag.com"
+              git config --global user.name "Automation"
+              . local-env/bin/activate
+              semantic-release publish
+              python setup.py sdist upload -r local
+
+workflows:
+    version: 2
+    build_and_deploy:
+      jobs:
+        - build:
+            context: org-global
+        - release:
+            context: org-global
+            requires:
+              - build
+            filters:
+              branches:
+                only:
+                  - artifactory

--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ jupyter-notebook ee-atmcorr-timeseries.ipynb --ip='*' --port=8888 --allow-root
 This code is optimized to run atmospheric correction of large image collections. It trades setup-time (i.e. ~30 mins) for run time. Setup is only performed once and is fully automated. This solves the problem of running radiative transfer code for each image which would take ~2 secs/scene, 500 scenes would therefore take over 16 mins (everytime).
 
 It does this using the [6S emulator](https://github.com/samsammurphy/6S_emulator) which is based on n-dimensional interpolated lookup tables (iLUTs). These iLUTs are automatically downloaded and constructed locally.
+
+## Publishing
+
+While integration work is in-progress we will be publishing to both tellus internal s3 pypi and artifactory
+
+* to publish to tellus internal s3 pypi, make sure s3 creds point to the correct account and run ./scripts/publish.sh
+* circleci will publish to artifactory and bases the version on semantic-release [commit formatting](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ py6s
 pandas
 earthengine-api
 s3pypi
+python-semantic-release

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [semantic_release]
-version_variable = atomcorr.__version__
+version_variable = ./atomcorr/__init__.py:__version__
 upload_to_pypi = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[semantic_release]
+version_variable = setup.py:__version__
+upload_to_pypi = false
+commit_parser=indigo.atmcorr.commit_parser.parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
 [semantic_release]
-version_variable = setup.py:__version__
+version_variable = atomcorr.__version__
 upload_to_pypi = false
-commit_parser=indigo.atmcorr.commit_parser.parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [semantic_release]
-version_variable = ./atomcorr/__init__.py:__version__
+version_variable = atmcorr/__init__.py:__version__
 upload_to_pypi = false

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@ from setuptools import setup, find_packages  # Always prefer setuptools over dis
 
 import atmcorr
 
-__version__ = '0.1.2'
-
 setup(
     name='atmcorr',
     version=atmcorr.__version__,

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,12 @@ from setuptools import setup, find_packages  # Always prefer setuptools over dis
 
 import atmcorr
 
+__version__ = '0.1.2'
+
 setup(
     name='atmcorr',
     version=atmcorr.__version__,
-    url='https://github.com/telluslabs/ee-atmcorr-timeseries',
+    url='https://github.com/indigo-ag/ee-atmcorr-timeseries',
     author='telluslabs',
     author_email='admin@telluslabs.com',
     description="TellusLabs Cassandra Connector",


### PR DESCRIPTION
Adding circleci workflow to publish new versions of package to artifactory.
It add new functionality in order to publish to artifactory but leaves the old scripts/publish.sh to be able to publish to pypi s3 in parallel.